### PR TITLE
Add FFD and gun detector placeholders

### DIFF
--- a/detector-ffd/Dockerfile
+++ b/detector-ffd/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /opt
+RUN pip install --no-cache-dir websockets prometheus_client
+COPY ffd_detector.py .
+CMD ["python", "ffd_detector.py"]

--- a/detector-ffd/ffd_detector.py
+++ b/detector-ffd/ffd_detector.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import time
+import prometheus_client as prom
+from prometheus_client import Counter
+import websockets
+
+WS_PORT = 8767
+PROM_PORT = 9105
+CAM_ID = "ffd_01"
+
+frames_total = Counter("ffd_frames_total", "Frames processed")
+alerts_total = Counter("ffd_alerts_total", "Alerts emitted", ["event"])
+
+async def detector_loop(ws):
+    while True:
+        frames_total.inc()
+        await asyncio.sleep(1)
+        if frames_total._value.get() % 10 == 0:
+            event = "fall_detected" if frames_total._value.get() % 20 == 0 else "fight_detected"
+            alert = {
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ", time.gmtime()),
+                "camera_id": CAM_ID,
+                "event": event,
+                "confidence": 0.9,
+                "bbox": [100, 100, 300, 300],
+            }
+            alerts_total.labels(event).inc()
+            await ws.send(json.dumps(alert))
+            print(f"Generated {event}")
+
+async def main():
+    prom.start_http_server(PROM_PORT)
+    async with websockets.serve(detector_loop, "0.0.0.0", WS_PORT):
+        print(f"FFD detector WebSocket @ :{WS_PORT}")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/detector-gun/Dockerfile
+++ b/detector-gun/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /opt
+RUN pip install --no-cache-dir websockets prometheus_client
+COPY gun_detector.py .
+CMD ["python", "gun_detector.py"]

--- a/detector-gun/gun_detector.py
+++ b/detector-gun/gun_detector.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import time
+import prometheus_client as prom
+from prometheus_client import Counter
+import websockets
+
+WS_PORT = 9106
+PROM_PORT = 9107
+CAM_ID = "thermal_gun_01"
+
+frames_total = Counter("gun_frames_total", "Frames processed")
+alerts_total = Counter("gun_alerts_total", "Alerts emitted", ["event"])
+
+async def detector_loop(ws):
+    while True:
+        frames_total.inc()
+        await asyncio.sleep(1)
+        if frames_total._value.get() % 10 == 0:
+            alert = {
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ", time.gmtime()),
+                "camera_id": CAM_ID,
+                "event": "weapon_detected",
+                "confidence": 0.9,
+                "bbox": [100, 100, 300, 300],
+            }
+            alerts_total.labels(alert["event"]).inc()
+            await ws.send(json.dumps(alert))
+            print("Generated weapon_detected")
+
+async def main():
+    prom.start_http_server(PROM_PORT)
+    async with websockets.serve(detector_loop, "0.0.0.0", WS_PORT):
+        print(f"Gun detector WebSocket @ :{WS_PORT}")
+        await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,9 @@ services:
       - "8766:8766"                   # WebSocket alerts (thermal)
 
   # ───────────────────────────── Thermal Gun detector ───────────────────────────
+
   detector-gun:
-    build: ./detector-thermal
+    build: ./detector-gun
     environment:
       - RTSP_URL=${THERMAL_RTSP_URL}  # thermal camera stream
       - BARSHIELD_DEVICE=${BARSHIELD_DEVICE:-cpu}
@@ -33,10 +34,10 @@ services:
       - ./weights:/opt/weights        # thermal weights
     restart: unless-stopped
     ports:
-      - "9106:9106"                   # WebSocket alerts + Prometheus metrics
+      - "9106:9106"                   # WebSocket alerts
+      - "9107:9107"                   # Prometheus metrics
     command: ["python", "gun_detector.py"]
 
-  # ───────────────────────────── Fight/Fall detector (MoveNet) ───────────────────────────
   detector-ffd:
     build: ./detector-ffd
     environment:
@@ -46,7 +47,6 @@ services:
     ports:
       - "8767:8767"                   # WebSocket alerts (FFD)
       - "9105:9105"                   # Prometheus metrics (FFD)
-
   # ─────────────────────────────── Fusion service ───────────────────────────────────────
   fusion:
     build: ./fusion


### PR DESCRIPTION
## Summary
- add placeholder FFD and gun detector images
- strip unused detector services from docker-compose
- restore FFD and gun services referencing new images

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*