### PR TITLE
Harden camera secret handling and local service exposure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and provide real values locally.
+# Never commit credentials or camera URLs containing usernames/passwords.
+
+RTSP_URL=rtsp://camera-host:8554/Streaming/Channels/201
+THERMAL_RTSP_URL=rtsp://thermal-camera-host:8554/stream
+BARSHIELD_DEVICE=cpu

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,24 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan repository history
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,50 +3,50 @@ services:
   detector-rgb:
     build: ./detector-rgb
     environment:
-      - RTSP_URL=rtsp://admin:1541Playdc7thst@10.1.10.239:8554/Streaming/Channels/201  # RGB camera stream
-      - BARSHIELD_DEVICE=${BARSHIELD_DEVICE:-cpu}  # defaulting to CPU mode
+      - RTSP_URL=${RTSP_URL:?RTSP_URL is required}
+      - BARSHIELD_DEVICE=${BARSHIELD_DEVICE:-cpu}
       - GUN_MODEL_PATH=/models/gun_yolov8n.pt
     volumes:
-      - ./models:/models:ro           # gun model weights
+      - ./models:/models:ro
     restart: unless-stopped
     ports:
-      - "8765:8765"                   # WebSocket alerts (RGB)
+      - "127.0.0.1:8765:8765"
 
   # ───────────────────────────── Thermal detector (YOLOv11‑T) ───────────────────────────
   detector-thermal:
     build: ./detector-thermal
     environment:
-      - RTSP_URL=${THERMAL_RTSP_URL}  # thermal camera stream
+      - RTSP_URL=${THERMAL_RTSP_URL:?THERMAL_RTSP_URL is required}
       - BARSHIELD_DEVICE=cpu
     volumes:
-      - ./weights:/opt/weights        # thermal weights
+      - ./weights:/opt/weights
     restart: unless-stopped
     ports:
-      - "8766:8766"                   # WebSocket alerts (thermal)
+      - "127.0.0.1:8766:8766"
 
   # ───────────────────────────── Thermal Gun detector ───────────────────────────
   detector-gun:
     build: ./detector-thermal
     environment:
-      - RTSP_URL=${THERMAL_RTSP_URL}  # thermal camera stream
+      - RTSP_URL=${THERMAL_RTSP_URL:?THERMAL_RTSP_URL is required}
       - BARSHIELD_DEVICE=${BARSHIELD_DEVICE:-cpu}
     volumes:
-      - ./weights:/opt/weights        # thermal weights
+      - ./weights:/opt/weights
     restart: unless-stopped
     ports:
-      - "9106:9106"                   # WebSocket alerts + Prometheus metrics
+      - "127.0.0.1:9106:9106"
     command: ["python", "gun_detector.py"]
 
   # ───────────────────────────── Fight/Fall detector (MoveNet) ───────────────────────────
   detector-ffd:
     build: ./detector-ffd
     environment:
-      - RTSP_URL=${RTSP_URL:-https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4}  # RGB camera stream for pose detection
+      - RTSP_URL=${RTSP_URL:?RTSP_URL is required}
       - BARSHIELD_DEVICE=${BARSHIELD_DEVICE:-cpu}
     restart: unless-stopped
     ports:
-      - "8767:8767"                   # WebSocket alerts (FFD)
-      - "9105:9105"                   # Prometheus metrics (FFD)
+      - "127.0.0.1:8767:8767"
+      - "127.0.0.1:9105:9105"
 
   # ─────────────────────────────── Fusion service ───────────────────────────────────────
   fusion:
@@ -58,7 +58,7 @@ services:
       - FFD_WS=ws://detector-ffd:8767
       - GUN_WS=ws://detector-gun:9106
     ports:
-      - "8770:8770"                   # Fused alerts WebSocket
+      - "127.0.0.1:8770:8770"
     restart: unless-stopped
 
   # ───────────────────────────── Observability stack ────────────────────────────────────
@@ -67,20 +67,20 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
 
   grafana:
     image: grafana/grafana-oss:latest
     depends_on: [prometheus]
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
 
   # ───────────────────────────── Dashboard UI ────────────────────────────────────
   dashboard:
     build: ./dashboard
     depends_on: [alertbus]
     ports:
-      - "5173:80"
+      - "127.0.0.1:5173:80"
     restart: unless-stopped
 
   # ───────────────────────────── Alert Bus ────────────────────────────────────

--- a/docs/security/CREDENTIAL-ROTATION-REGISTER.md
+++ b/docs/security/CREDENTIAL-ROTATION-REGISTER.md
@@ -1,0 +1,22 @@
+# Credential Rotation Register
+
+Status labels in this document describe evidence available in the repository. Secret values are intentionally omitted.
+
+| System | Exposure | State | Required owner action | Deployment gate |
+|---|---|---|---|---|
+| RGB IP camera / NVR account | A credential-bearing RTSP URL was committed to source, Docker configuration, and an attached text asset | **Verified** | Rotate the camera/NVR password; revoke the prior credential; inspect remote-access and port-forwarding rules; review device access logs; confirm the replacement credential is unique | **Blocked** until rotation is confirmed |
+| Repository Git history | The sensitive URL remains reachable from prior commits after active files are patched | **Verified** | Rewrite affected history, invalidate stale clones, and request cache cleanup where required | **Blocked** until history cleanup is completed |
+| Deployment environments | It is unknown whether the exposed credential was copied into external hosts, CI variables, shell history, screenshots, or documentation | **Assumed** | Search each deployment environment and rotate/remove any copies found | **Blocked** pending owner verification |
+
+## Required incident sequence
+
+1. Rotate the affected camera/NVR credential before merging this patch.
+2. Disable direct internet exposure and public port forwarding for camera services.
+3. Store replacement stream URLs in a local `.env` file or managed secret store.
+4. Verify `.env` remains ignored and never paste secret-bearing URLs into issues, logs, screenshots, or chat.
+5. Complete the Git-history procedure in `GIT-HISTORY-CLEANUP.md`.
+6. Re-scan all branches and tags before reopening deployment.
+
+## Evidence boundary
+
+This register does not prove that rotation, network isolation, or history cleanup has occurred. Those items remain **Blocked** until a human owner records completion evidence without disclosing the new credential.

--- a/docs/security/GIT-HISTORY-CLEANUP.md
+++ b/docs/security/GIT-HISTORY-CLEANUP.md
@@ -1,0 +1,49 @@
+# Git History Cleanup Procedure
+
+> Perform this only after the exposed camera/NVR credential has been rotated. History rewriting is disruptive and requires every collaborator to replace stale clones.
+
+## Scope
+
+Remove the credential-bearing RTSP URL from every branch and tag, including copies in:
+
+- `server/video-processor.ts`
+- `docker-compose.yml`
+- attached text assets and generated documentation
+- any other path identified by a full-history secret scan
+
+Do not copy the secret into command history. Store the exact text temporarily in a protected local file outside the repository and securely delete it after cleanup.
+
+## Recommended procedure
+
+1. Create an offline backup of the repository for incident evidence and restrict access to it.
+2. Notify collaborators that pushes are frozen during cleanup.
+3. Use a fresh mirror clone.
+4. Run `git-filter-repo` with a replacement-expression file that replaces the full compromised URL and credential fragments with `***REMOVED***`.
+5. Run Gitleaks or an equivalent full-history scan over all refs.
+6. Inspect tags, pull-request references, releases, artifacts, issues, Actions logs, and package/container registries for copies.
+7. Force-push cleaned branches and tags only after the scan passes.
+8. Ask collaborators to delete existing clones and clone again. Do not merge old branches back into the cleaned repository.
+9. Contact GitHub Support when unreachable cached references or pull-request objects still expose the removed value.
+10. Record the cleanup commit/time and scanner output without recording the secret.
+
+## Example command shape
+
+The following is intentionally incomplete so the compromised value is never copied from this document:
+
+```bash
+git clone --mirror <repository-url>
+cd BarSecurityTracker.git
+git filter-repo --replace-text /secure/path/replacements.txt
+# Run a full-history scanner here.
+git push --force --mirror
+```
+
+## Completion evidence
+
+History cleanup remains **Blocked** until all of the following are recorded:
+
+- credential rotation confirmation
+- full-ref scan result
+- force-push completion
+- collaborator stale-clone notification
+- review of external caches and build artifacts

--- a/server/video-processor.ts
+++ b/server/video-processor.ts
@@ -2,50 +2,12 @@ import ffmpeg from 'ffmpeg-static';
 import { spawn } from 'child_process';
 import { storage } from './storage';
 
-const RTSP_URL = 'rtsp://admin:1541Playdc7thst@10.1.10.239:8554/Streaming/Channels/201';
 const HLS_OUTPUT_DIR = './public/hls';
 const SEGMENT_DURATION = 2;
+const ALLOWED_STREAM_PROTOCOLS = new Set(['rtsp:', 'rtsps:']);
 
-export class VideoProcessor {
-  private ffmpegProcess: ReturnType<typeof spawn> | null = null;
-
-  startStreaming() {
-    const args = [
-      '-i', RTSP_URL,
-      '-c:v', 'libx264',
-      '-preset', 'veryfast',
-      '-tune', 'zerolatency',
-      '-c:a', 'aac',
-      '-f', 'hls',
-      '-hls_time', SEGMENT_DURATION.toString(),
-      '-hls_list_size', '3',
-      '-hls_flags', 'delete_segments',
-      '-hls_segment_filename', `${HLS_OUTPUT_DIR}/segment_%d.ts`,
-      `${HLS_OUTPUT_DIR}/playlist.m3u8`
-    ];
-
-    this.ffmpegProcess = spawn(ffmpeg, args);
-
-    this.ffmpegProcess.stderr?.on('data', (data) => {
-      console.log('FFmpeg:', data.toString());
-    });
-
-    this.ffmpegProcess.on('error', (error) => {
-      console.error('FFmpeg error:', error);
-      storage.createEvent({
-        type: 'ERROR',
-        description: `FFmpeg error: ${error.message}`,
-        objects: []
-      });
-    });
-  }
-
-  stopStreaming() {
-    if (this.ffmpegProcess) {
-      this.ffmpegProcess.kill();
-      this.ffmpegProcess = null;
-    }
-  }
-}
-
-export const videoProcessor = new VideoProcessor();
+/**
+ * Reads and validates the camera stream URL without providing an unsafe default.
+ * Production must fail closed when the configured camera is unavailable.
+ */
+export

--- a/server/video-processor.ts
+++ b/server/video-processor.ts
@@ -6,8 +6,101 @@ const HLS_OUTPUT_DIR = './public/hls';
 const SEGMENT_DURATION = 2;
 const ALLOWED_STREAM_PROTOCOLS = new Set(['rtsp:', 'rtsps:']);
 
-/**
- * Reads and validates the camera stream URL without providing an unsafe default.
- * Production must fail closed when the configured camera is unavailable.
- */
-export
+function getCameraStreamUrl(): string {
+  const configuredUrl = process.env.CAMERA_RTSP_URL ?? process.env.RTSP_URL;
+
+  if (!configuredUrl) {
+    throw new Error('CAMERA_RTSP_URL or RTSP_URL is required');
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(configuredUrl);
+  } catch {
+    throw new Error('The configured camera stream URL is invalid');
+  }
+
+  if (!ALLOWED_STREAM_PROTOCOLS.has(parsedUrl.protocol)) {
+    throw new Error('The camera stream URL must use rtsp:// or rtsps://');
+  }
+
+  return configuredUrl;
+}
+
+function redactCredentials(value: string): string {
+  return value.replace(/(rtsps?:\/\/)([^\s/@:]+):([^\s/@]+)@/gi, '$1***:***@');
+}
+
+export class VideoProcessor {
+  private ffmpegProcess: ReturnType<typeof spawn> | null = null;
+
+  startStreaming() {
+    if (this.ffmpegProcess) {
+      return;
+    }
+
+    let streamUrl: string;
+    try {
+      streamUrl = getCameraStreamUrl();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Camera configuration failed';
+      storage.createEvent({
+        type: 'ERROR',
+        description: message,
+        objects: []
+      });
+      throw error;
+    }
+
+    if (!ffmpeg) {
+      throw new Error('FFmpeg executable is unavailable');
+    }
+
+    const args = [
+      '-hide_banner',
+      '-loglevel', 'warning',
+      '-i', streamUrl,
+      '-c:v', 'libx264',
+      '-preset', 'veryfast',
+      '-tune', 'zerolatency',
+      '-c:a', 'aac',
+      '-f', 'hls',
+      '-hls_time', SEGMENT_DURATION.toString(),
+      '-hls_list_size', '3',
+      '-hls_flags', 'delete_segments',
+      '-hls_segment_filename', `${HLS_OUTPUT_DIR}/segment_%d.ts`,
+      `${HLS_OUTPUT_DIR}/playlist.m3u8`
+    ];
+
+    this.ffmpegProcess = spawn(ffmpeg, args, {
+      stdio: ['ignore', 'ignore', 'pipe']
+    });
+
+    this.ffmpegProcess.stderr?.on('data', (data) => {
+      console.error('FFmpeg:', redactCredentials(data.toString()));
+    });
+
+    this.ffmpegProcess.on('error', (error) => {
+      const safeMessage = redactCredentials(error.message);
+      console.error('FFmpeg error:', safeMessage);
+      storage.createEvent({
+        type: 'ERROR',
+        description: `FFmpeg error: ${safeMessage}`,
+        objects: []
+      });
+    });
+
+    this.ffmpegProcess.on('exit', () => {
+      this.ffmpegProcess = null;
+    });
+  }
+
+  stopStreaming() {
+    if (this.ffmpegProcess) {
+      this.ffmpegProcess.kill();
+      this.ffmpegProcess = null;
+    }
+  }
+}
+
+export const videoProcessor = new VideoProcessor();


### PR DESCRIPTION
## What changed

- removed the embedded credential-bearing RTSP URL from the active video processor
- required camera stream URLs from environment configuration with fail-closed validation
- redacted credentials from FFmpeg stderr and process error logs
- removed hard-coded camera credentials from Docker Compose
- bound detector, fusion, dashboard, Prometheus, and Grafana ports to localhost by default
- added a safe `.env.example`
- added a full-history Gitleaks workflow
- added a credential-rotation register and Git-history cleanup procedure

## Why

A camera/NVR credential was committed in multiple repository paths. Deleting only the active line would leave the secret in history and could allow it to leak through FFmpeg logs. This patch contains active exposure and creates the documented incident workflow, but it does not rotate the device credential or rewrite Git history.

## Evidence states

- **Verified:** active source and Compose no longer contain the embedded camera credential on this branch
- **Implemented but untested:** environment validation, credential redaction, localhost-only port bindings, and Gitleaks workflow
- **Blocked:** camera/NVR credential rotation, external deployment inspection, Git-history rewriting, stale clone invalidation, and cache cleanup

## Validation

- re-read the complete updated `server/video-processor.ts` from the branch after writing it
- compared the branch against `main`; the branch is ahead with only the intended security files
- runtime build and tests were not executed in this environment because GitHub CLI/local checkout tooling is unavailable

## Required before merge

1. Rotate the affected camera/NVR password and revoke the old credential.
2. Confirm the camera is not directly exposed to the public internet.
3. Review and approve the history-cleanup plan.
4. Let the secret-scan workflow complete and inspect its result.
